### PR TITLE
Fix delete loops error handling

### DIFF
--- a/src/features/chat-page/chat-menu/chat-menu-service.ts
+++ b/src/features/chat-page/chat-menu/chat-menu-service.ts
@@ -24,11 +24,17 @@ export const DeleteAllChatThreads = async (): Promise<
 
   if (chatThreadResponse.status === "OK") {
     const chatThreads = chatThreadResponse.response;
-    const promise = chatThreads.map(async (chatThread) => {
-      return SoftDeleteChatThreadForCurrentUser(chatThread.id);
-    });
 
-    await Promise.all(promise);
+    for (const chatThread of chatThreads) {
+      const result = await SoftDeleteChatThreadForCurrentUser(chatThread.id);
+      if (result.status !== "OK") {
+        return {
+          status: result.status,
+          errors: result.errors,
+        };
+      }
+    }
+
     RevalidateCache({
       page: "chat",
       type: "layout",

--- a/src/features/chat-page/chat-services/chat-thread-service.ts
+++ b/src/features/chat-page/chat-services/chat-thread-service.ts
@@ -130,13 +130,20 @@ export const SoftDeleteChatThreadForCurrentUser = async (
       }
       const chats = chatResponse.response;
 
-      chats.forEach(async (chat) => {
+      for (const chat of chats) {
         const itemToUpdate = {
           ...chat,
+          isDeleted: true,
         };
-        itemToUpdate.isDeleted = true;
-        await HistoryContainer().items.upsert(itemToUpdate);
-      });
+        try {
+          await HistoryContainer().items.upsert(itemToUpdate);
+        } catch (e) {
+          return {
+            status: "ERROR",
+            errors: [{ message: `${e}` }],
+          };
+        }
+      }
 
       const chatDocumentsResponse = await FindAllChatDocuments(chatThreadID);
 
@@ -150,13 +157,20 @@ export const SoftDeleteChatThreadForCurrentUser = async (
         await DeleteDocuments(chatThreadID);
       }
 
-      chatDocuments.forEach(async (chatDocument: ChatDocumentModel) => {
+      for (const chatDocument of chatDocuments) {
         const itemToUpdate = {
           ...chatDocument,
+          isDeleted: true,
         };
-        itemToUpdate.isDeleted = true;
-        await HistoryContainer().items.upsert(itemToUpdate);
-      });
+        try {
+          await HistoryContainer().items.upsert(itemToUpdate);
+        } catch (e) {
+          return {
+            status: "ERROR",
+            errors: [{ message: `${e}` }],
+          };
+        }
+      }
 
       chatThreadResponse.response.isDeleted = true;
       await HistoryContainer().items.upsert(chatThreadResponse.response);


### PR DESCRIPTION
## Summary
- handle `await` in chat deletion loops
- surface errors from bulk thread delete

## Testing
- `npm run lint` *(fails: next not found)*