### PR TITLE
Add animated chat intro

### DIFF
--- a/src/features/chat-home-page/chat-home.tsx
+++ b/src/features/chat-home-page/chat-home.tsx
@@ -1,13 +1,16 @@
 import { AddExtension } from "@/features/extensions-page/add-extension/add-new-extension";
-import { ExtensionCard } from "@/features/extensions-page/extension-card/extension-card";
 import { ExtensionModel } from "@/features/extensions-page/extension-services/models";
-import { PersonaCard } from "@/features/persona-page/persona-card/persona-card";
 import { PersonaModel } from "@/features/persona-page/persona-services/models";
 import { AI_DESCRIPTION, AI_NAME } from "@/features/theme/theme-config";
 import { Hero } from "@/features/ui/hero";
 import { ScrollArea } from "@/features/ui/scroll-area";
+import { TypewriterText } from "@/features/ui/typewriter-text";
+import { Button } from "@/features/ui/button";
+import { CreateChatAndRedirect } from "@/features/chat-page/chat-services/chat-thread-service";
 import Image from "next/image";
+import Link from "next/link";
 import { FC } from "react";
+import { MessageCircle, VenetianMask } from "lucide-react";
 
 interface ChatPersonaProps {
   personas: PersonaModel[];
@@ -31,33 +34,25 @@ export const ChatHome: FC<ChatPersonaProps> = (props) => {
               {AI_NAME}
             </>
           }
-          description={AI_DESCRIPTION}
-        ></Hero>
+          description={<TypewriterText text={AI_DESCRIPTION} />}
+        >
+          <form action={CreateChatAndRedirect} className="w-full">
+            <Button
+              className="bg-mallingBurgund-800 hover:bg-mallingBurgund-700 text-white text-lg px-6 py-4 w-full flex gap-2 justify-center"
+            >
+              <MessageCircle size={20} /> Ny samtale
+            </Button>
+          </form>
+          <Link href="/persona" className="w-full">
+            <Button
+              variant="outline"
+              className="w-full flex gap-2 justify-center text-mallingBurgund-800 border-mallingBurgund-800"
+            >
+              <VenetianMask size={20} /> Personligheter
+            </Button>
+          </Link>
+        </Hero>
 
-      
-        <div className="container max-w-4xl flex gap-20 flex-col">
-          <div>
-            <h2 className="text-2xl font-bold mb-3">Personlighet</h2>
-
-            {props.personas && props.personas.length > 0 ? (
-              <div className="grid grid-cols-3 gap-3">
-                {props.personas.map((persona) => {
-                  return (
-                    <PersonaCard
-                      persona={persona}
-                      key={persona.id}
-                      showContextMenu={false}
-                    />
-                  );
-                })}
-              </div>
-            ) : (
-              <p className="text-muted-foreground max-w-xl">
-                Du har ikke laget noen personligheter
-              </p>
-            )}
-          </div>
-        </div>
         <AddExtension />
       </main>
     </ScrollArea>

--- a/src/features/theme/theme-config.ts
+++ b/src/features/theme/theme-config.ts
@@ -1,5 +1,6 @@
 export const AI_NAME = "MallingChat";
-export const AI_DESCRIPTION = "Klikk Ny samtale for å starte en chat med Mallings helt egne AI. Kontakt jorgen.nesmoen@malling.no dersom du trenger hjelp med denne løsningen.";
+export const AI_DESCRIPTION =
+  "Malling sin egen AI er helt trygg å bruke. Start en ny samtale for å chatte, laste opp filer og utforske personligheter og utvidelser.";
 export const CHAT_DEFAULT_PERSONA = AI_NAME + " standard";
 
 export const CHAT_DEFAULT_SYSTEM_PROMPT = `Du er ${AI_NAME}, en effektiv og hjelpsom AI-assistent for Malling. Du velger alltid det mest hensiktsmessige formatet på ditt svar for å imøtekomme brukernes behov på en rask og brukervennlig måte. Du stiller oppfølgende spørsmål dersom du ikke kan løse oppgaven du er gitt på en god måte. Du er ikke trent med interne data fra Malling så du viser alltid til Intranett for Malling-spesifikke spørsmål (https://mallingco.sharepoint.com/sites/Intranett). 

--- a/src/features/ui/hero.tsx
+++ b/src/features/ui/hero.tsx
@@ -3,7 +3,7 @@ import { FC, PropsWithChildren } from "react";
 
 interface HeroProps extends PropsWithChildren {
   title: React.ReactNode;
-  description: string;
+  description: React.ReactNode;
 }
 
 export const Hero: FC<HeroProps> = (props) => {

--- a/src/features/ui/typewriter-text.tsx
+++ b/src/features/ui/typewriter-text.tsx
@@ -1,0 +1,30 @@
+import { FC, useEffect, useState } from "react";
+
+interface Props {
+  text: string;
+  speed?: number;
+}
+
+export const TypewriterText: FC<Props> = ({ text, speed = 40 }) => {
+  const [displayed, setDisplayed] = useState("");
+
+  useEffect(() => {
+    setDisplayed("");
+    let index = 0;
+    const id = setInterval(() => {
+      setDisplayed((prev) => prev + text.charAt(index));
+      index += 1;
+      if (index >= text.length) {
+        clearInterval(id);
+      }
+    }, speed);
+    return () => clearInterval(id);
+  }, [text, speed]);
+
+  return (
+    <span>
+      {displayed}
+      <span className="animate-pulse">|</span>
+    </span>
+  );
+};


### PR DESCRIPTION
## Summary
- update AI description in theme config
- allow Hero description to be React node
- add typewriter animation component
- redesign ChatHome hero with typewriter text and large burgundy buttons

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test script)*