### PR TITLE
Add client directive to typewriter component

### DIFF
--- a/src/features/ui/typewriter-text.tsx
+++ b/src/features/ui/typewriter-text.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FC, useEffect, useState } from "react";
 
 interface Props {


### PR DESCRIPTION
## Summary
- ensure `TypewriterText` is marked as a client component

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: EHOSTUNREACH)*