### PR TITLE
Add per-thread deployment option

### DIFF
--- a/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
@@ -16,7 +16,7 @@ export const ChatApiExtensions = async (props: {
 }): Promise<ChatCompletionStreamingRunner> => {
   const { userMessage, history, signal, chatThread, extensions } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(chatThread.deploymentName);
   const systemMessage = await extensionsSystemMessage(chatThread);
   return openAI.beta.chat.completions.runTools(
     {

--- a/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
@@ -12,7 +12,7 @@ export const ChatApiMultimodal = (props: {
 }): ChatCompletionStreamingRunner => {
   const { chatThread, userMessage, signal, file } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(chatThread.deploymentName);
 
   return openAI.beta.chat.completions.stream(
     {

--- a/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
@@ -20,7 +20,7 @@ export const ChatApiRAG = async (props: {
 }): Promise<ChatCompletionStreamingRunner> => {
   const { chatThread, userMessage, history, signal } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(chatThread.deploymentName);
 
   const documentResponse = await SimilaritySearch(
     userMessage,

--- a/src/features/chat-page/chat-services/chat-thread-service.ts
+++ b/src/features/chat-page/chat-services/chat-thread-service.ts
@@ -262,6 +262,11 @@ export const UpsertChatThread = async (
       }
     }
 
+    if (!chatThread.deploymentName) {
+      chatThread.deploymentName =
+        process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "";
+    }
+
     chatThread.lastMessageAt = new Date();
     const { resource } = await HistoryContainer().items.upsert<ChatThreadModel>(
       chatThread
@@ -286,7 +291,9 @@ export const UpsertChatThread = async (
   }
 };
 
-export const CreateChatThread = async (): Promise<
+export const CreateChatThread = async (
+  deploymentName?: string
+): Promise<
   ServerActionResponse<ChatThreadModel>
 > => {
   try {
@@ -303,6 +310,8 @@ export const CreateChatThread = async (): Promise<
       personaMessage: "",
       personaMessageTitle: CHAT_DEFAULT_PERSONA,
       extension: [],
+      deploymentName:
+        deploymentName || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "",
     };
 
     const { resource } = await HistoryContainer().items.create<ChatThreadModel>(

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -33,6 +33,7 @@ export interface ChatThreadModel {
   personaMessage: string;
   personaMessageTitle: string;
   extension: string[];
+  deploymentName: string;
   type: typeof CHAT_THREAD_ATTRIBUTE;
 }
 

--- a/src/features/common/services/openai.ts
+++ b/src/features/common/services/openai.ts
@@ -1,10 +1,11 @@
 import { OpenAI } from "openai";
 
-export const OpenAIInstance = () => {
+export const OpenAIInstance = (deploymentName?: string) => {
   const endpointSuffix = process.env.AZURE_OPENAI_API_ENDPOINT_SUFFIX || "openai.azure.com";
+  const deployment = deploymentName || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME;
   const openai = new OpenAI({
     apiKey: process.env.AZURE_OPENAI_API_KEY,
-    baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME}`,
+    baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deployment}`,
     defaultQuery: { "api-version": process.env.AZURE_OPENAI_API_VERSION },
     defaultHeaders: { "api-key": process.env.AZURE_OPENAI_API_KEY },
   });

--- a/src/features/extensions-page/extension-services/extension-service.ts
+++ b/src/features/extensions-page/extension-services/extension-service.ts
@@ -399,6 +399,8 @@ export const CreateChatWithExtension = async (
       personaMessage: "",
       personaMessageTitle: CHAT_DEFAULT_PERSONA,
       extension: [extension.id],
+      deploymentName:
+        process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "",
     });
 
     return response;

--- a/src/features/persona-page/persona-services/persona-service.ts
+++ b/src/features/persona-page/persona-services/persona-service.ts
@@ -283,7 +283,8 @@ export const FindAllPersonaForCurrentUser = async (): Promise<
 };
 
 export const CreatePersonaChat = async (
-  personaId: string
+  personaId: string,
+  deploymentName?: string
 ): Promise<ServerActionResponse<ChatThreadModel>> => {
   const personaResponse = await FindPersonaByID(personaId);
   const user = await getCurrentUser();
@@ -304,6 +305,8 @@ export const CreatePersonaChat = async (
       personaMessage: persona.personaMessage,
       personaMessageTitle: persona.name,
       extension: [],
+      deploymentName:
+        deploymentName || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "",
     });
 
     return response;


### PR DESCRIPTION
## Summary
- add `deploymentName` field to `ChatThreadModel`
- allow chat thread creation services to set deployment name
- ensure `OpenAIInstance` handles custom deployments
- forward deployment name to chat API modules
- default missing deployment names when upserting threads

## Testing
- `npm run lint` *(fails: `next` not found)*