### PR TITLE
Add instructions for multiple OpenAI deployments

### DIFF
--- a/docs/1-introduction.md
+++ b/docs/1-introduction.md
@@ -4,7 +4,9 @@ Please make sure the following prerequisites are in place prior to deploying thi
 
 1. [Azure OpenAI](https://azure.microsoft.com/en-us/products/cognitive-services/openai-service/): To deploy and run the solution accelerator, you'll need an Azure subscription with access to the Azure OpenAI service. Request access [here](https://customervoice.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR7en2Ais5pxKtso_Pz4b1_xUOFA5Qk1UWDRBMjg0WFhPMkIzTzhKQ1dWNyQlQCN0PWcu). Once you have access, follow the instructions in this [link](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal) to deploy the gpt-35-turbo or gpt-4 models.
 
-2. Setup GitHub or Azure AD for Authentication:
+2. **Create Azure OpenAI deployments**: In the [Azure OpenAI Studio](https://oai.azure.com/portal), create a deployment for each model you intend to use (for example GPT models, Embeddings and DALL-E). Capture the name of each deployment as these values are required when configuring the application.
+
+3. Setup GitHub or Azure AD for Authentication:
    The [add an identity provider](./5-add-identity.md) section below shows how to configure authentication providers.
 
 > [!NOTE]

--- a/docs/9-environment-variables.md
+++ b/docs/9-environment-variables.md
@@ -1,3 +1,9 @@
 # 🔑 Environment Variables
 
-Refer to the [`.env.example`](../src/.env.example) for the required environment variables
+Refer to the [`.env.example`](../src/.env.example) for the required environment variables.
+
+The application expects the `AZURE_OPENAI_MODEL_DEPLOYMENTS` variable to contain the names of each Azure OpenAI deployment. Use a JSON string in the following format:
+
+```json
+{"gpt4o":"gpt4o-deployment","gpt35turbo":"gpt35-deployment","embedding":"embedding-deployment"}
+```

--- a/src/.env.example
+++ b/src/.env.example
@@ -18,6 +18,10 @@ AZURE_OPENAI_DALLE_API_INSTANCE_NAME=azurechat-dall-e
 AZURE_OPENAI_DALLE_API_DEPLOYMENT_NAME=dall-e
 AZURE_OPENAI_DALLE_API_VERSION=2023-12-01-preview
 
+# List of OpenAI deployments in JSON format. Each property represents a model and the value is the deployment name.
+# Example: {"gpt4o":"gpt4o-deployment","gpt35turbo":"gpt35-deployment","embedding":"embedding-deployment"}
+AZURE_OPENAI_MODEL_DEPLOYMENTS={"gpt4o":"gpt4o-deployment","gpt35turbo":"gpt35-deployment","embedding":"embedding-deployment"}
+
 # Update your admin email addresses - comma separated
 ADMIN_EMAIL_ADDRESS=alfred.robot@malling.no,you2@email.com
 


### PR DESCRIPTION
## Summary
- document creating OpenAI deployments and capturing the names
- add `AZURE_OPENAI_MODEL_DEPLOYMENTS` variable example
- describe new variable in environment variable docs

## Testing
- `npm run lint` *(fails: next not found)*