### PR TITLE
Add configurable OpenAI deployments

### DIFF
--- a/docs/4-deploy-to-azure.md
+++ b/docs/4-deploy-to-azure.md
@@ -37,4 +37,23 @@ Once the secrets are configured, the GitHub Actions will be triggered for every 
 
 ![Workflow screenshot](/docs/images/runworkflow.png)
 
+## Additional OpenAI deployments
+
+The Bicep templates deploy a default ChatGPT and embedding model. You can create extra deployments by passing them through the `additionalOpenAIDeployments` parameter. Each entry should define `name`, `modelName`, `modelVersion` and `capacity`:
+
+```json
+{
+  "additionalOpenAIDeployments": {
+    "value": [
+      {
+        "name": "gpt4turbo",
+        "modelName": "gpt-4-turbo",
+        "modelVersion": "2024-04-01",
+        "capacity": 25
+      }
+    ]
+  }
+}
+```
+
 [Next](/docs/5-add-identity.md)

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,6 +30,9 @@ param embeddingDeploymentName string = 'embedding'
 param embeddingDeploymentCapacity int = 120
 param embeddingModelName string = 'text-embedding-3-large'
 
+@description('Optional array of additional OpenAI deployments to create. Each item should contain name, modelName, modelVersion and capacity properties.')
+param additionalOpenAIDeployments array = []
+
 // DALL-E v3 only supported in limited regions for now
 @description('Location for the OpenAI DALL-E 3 instance resource group')
 @allowed(['swedencentral', 'eastus', 'australiaeast'])
@@ -76,6 +79,7 @@ module resources 'resources.bicep' = {
     embeddingDeploymentName: embeddingDeploymentName
     embeddingDeploymentCapacity: embeddingDeploymentCapacity
     embeddingModelName: embeddingModelName
+    additionalOpenAIDeployments: additionalOpenAIDeployments
     location: location
   }
 }


### PR DESCRIPTION
## Summary
- support extra OpenAI deployments via new `additionalOpenAIDeployments` param
- loop over deployments in Bicep
- document new parameter in deployment guide

## Testing
- `npm run lint` *(fails: next not found)*