### PR TITLE
Ensure deployment name is required

### DIFF
--- a/src/features/common/services/openai.ts
+++ b/src/features/common/services/openai.ts
@@ -3,6 +3,11 @@ import { OpenAI } from "openai";
 export const OpenAIInstance = (deploymentName?: string) => {
   const endpointSuffix = process.env.AZURE_OPENAI_API_ENDPOINT_SUFFIX || "openai.azure.com";
   const deployment = deploymentName || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME;
+  if (!deployment) {
+    throw new Error(
+      "Azure OpenAI deployment name is not set. Provide a deployment name or set AZURE_OPENAI_API_DEPLOYMENT_NAME."
+    );
+  }
   const openai = new OpenAI({
     apiKey: process.env.AZURE_OPENAI_API_KEY,
     baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deployment}`,


### PR DESCRIPTION
## Summary
- validate that the deployment name for the OpenAI service is provided

## Testing
- `npm run lint` *(fails: `next` not found)*