### PR TITLE
Update docs for deploymentName

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 1. [Environment variables](/docs/9-environment-variables.md)
 1. [Migration considerations](/docs/migration.md)
 
+> **Note**
+> Each conversation stores the Azure OpenAI deployment it uses in the
+> `deploymentName` field of `ChatThreadModel`. When starting a new chat you can
+> specify this deployment name. If omitted, the app uses the deployment name from
+> the `AZURE_OPENAI_API_DEPLOYMENT_NAME` environment variable.
+
 # Introduction
 
 _Azure Chat Solution Accelerator powered by Azure OpenAI Service_

--- a/docs/9-environment-variables.md
+++ b/docs/9-environment-variables.md
@@ -15,3 +15,10 @@ Key OpenAI settings include:
 - `AZURE_OPENAI_MODEL_DEPLOYMENTS` – JSON mapping of model names to deployment names.
 - `AZURE_OPENAI_API_DEPLOYMENT_NAME` – deployment name of the default model.
 
+Each conversation is represented by a `ChatThreadModel`. A new optional field
+`deploymentName` was introduced to record which Azure OpenAI deployment a chat
+uses. When creating a new chat thread (for example via `CreateChatThread` or
+`CreatePersonaChat`) you can specify the deployment name to use. If omitted, the
+chat thread automatically defaults to the value of
+`AZURE_OPENAI_API_DEPLOYMENT_NAME`.
+


### PR DESCRIPTION
## Summary
- explain new `deploymentName` field in environment variable docs
- note how deployment name can be set when starting a new chat

## Testing
- `npm run lint` *(fails: next not found)*