### PR TITLE
Fix Node.js version in webapp workflow

### DIFF
--- a/.github/workflows/main_mallingchat-webapp-brqdzib6youe4.yml
+++ b/.github/workflows/main_mallingchat-webapp-brqdzib6youe4.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
 
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r


### PR DESCRIPTION
## Summary
- use Node.js 20 in mallingchat webapp workflow
- ensure all workflows use the same Node version

## Testing
- `grep -R "node-version" -n .github/workflows`