### PR TITLE
Update dockerignore for local secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,8 @@ Dockerfile
 .git
 .gitignore
 src/.next
+
+# Ignore local environment files
+.env
+.env.*
+src/.env*


### PR DESCRIPTION
## Summary
- avoid sending .env secrets to Docker build context

## Testing
- `npm run lint` *(fails: next not found)*