### PR TITLE
Add Next link for docker guide

### DIFF
--- a/docs/7-build-docker-image.md
+++ b/docs/7-build-docker-image.md
@@ -24,3 +24,5 @@ The API will now be reachable at `http://localhost:3000`.
 
 For information on the required variables, see [Environment variables](./9-environment-variables.md).
 
+
+[Next](/docs/8-extensions.md)


### PR DESCRIPTION
## Summary
- add `[Next](/docs/8-extensions.md)` link to finish `7-build-docker-image.md`

## Testing
- `npm run lint` *(fails: next not found)*