### PR TITLE
Move model selector to new chat header

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -12,7 +12,7 @@ AZURE_OPENAI_API_DEPLOYMENT_NAME=gpt-4
 # AZURE_OPENAI_MODEL_DEPLOYMENTS maps model names to deployment names in JSON format
 # Example: {"gpt-35-turbo":"turbo-deployment","gpt-4o":"gpt-4o-deployment"}
 AZURE_OPENAI_MODEL_DEPLOYMENTS=
-AZURE_OPENAI_API_VERSION=2023-12-01-preview
+AZURE_OPENAI_API_VERSION=2024-12-01-preview
 AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME=embedding
 
 # DALL-E image creation endpoint config

--- a/src/app/(authenticated)/chat/[id]/page.tsx
+++ b/src/app/(authenticated)/chat/[id]/page.tsx
@@ -3,6 +3,7 @@ import { FindAllChatDocuments } from "@/features/chat-page/chat-services/chat-do
 import { FindAllChatMessagesForCurrentUser } from "@/features/chat-page/chat-services/chat-message-service";
 import { FindChatThreadForCurrentUser } from "@/features/chat-page/chat-services/chat-thread-service";
 import { FindAllExtensionForCurrentUser } from "@/features/extensions-page/extension-services/extension-service";
+import { getModelDeploymentMapping } from "@/features/common/services/model-mapping";
 import { AI_NAME } from "@/features/theme/theme-config";
 import { DisplayError } from "@/features/ui/error/display-error";
 
@@ -26,6 +27,7 @@ export default async function Home(props: HomeParams) {
       FindAllChatDocuments(id),
       FindAllExtensionForCurrentUser(),
     ]);
+  const modelMapping = getModelDeploymentMapping();
 
   if (docsResponse.status !== "OK") {
     return <DisplayError errors={docsResponse.errors} />;
@@ -49,6 +51,7 @@ export default async function Home(props: HomeParams) {
       chatThread={chatThreadResponse.response}
       chatDocuments={docsResponse.response}
       extensions={extensionResponse.response}
+      modelMapping={modelMapping}
     />
   );
 }

--- a/src/features/chat-home-page/chat-home.tsx
+++ b/src/features/chat-home-page/chat-home.tsx
@@ -6,8 +6,6 @@ import { Hero } from "@/features/ui/hero";
 import { ScrollArea } from "@/features/ui/scroll-area";
 import { TypewriterText } from "@/features/ui/typewriter-text";
 import { Button } from "@/features/ui/button";
-import { cn } from "@/ui/lib";
-import { getModelDeploymentMapping } from "@/features/common/services/model-mapping";
 import { CreateChatAndRedirect } from "@/features/chat-page/chat-services/chat-thread-service";
 import Image from "next/image";
 import Link from "next/link";
@@ -20,7 +18,6 @@ interface ChatPersonaProps {
 }
 
 export const ChatHome: FC<ChatPersonaProps> = (props) => {
-  const modelMapping = getModelDeploymentMapping();
   return (
     <ScrollArea className="flex-1">
       <main className="flex flex-1 flex-col gap-6 pb-6">
@@ -40,22 +37,6 @@ export const ChatHome: FC<ChatPersonaProps> = (props) => {
           description={<TypewriterText text={AI_DESCRIPTION} />}
         >
           <form action={CreateChatAndRedirect} className="w-full space-y-2">
-            {Object.keys(modelMapping).length > 0 && (
-              <select
-                name="deploymentName"
-                className={cn(
-                  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                )}
-                defaultValue={Object.values(modelMapping)[0]}
-                aria-label="Velg modell"
-              >
-                {Object.entries(modelMapping).map(([model, deployment]) => (
-                  <option key={model} value={deployment}>
-                    {model}
-                  </option>
-                ))}
-              </select>
-            )}
             <Button
               className="bg-mallingBurgund-800 hover:bg-mallingBurgund-700 text-white text-lg px-6 py-4 w-full flex gap-2 justify-center"
             >
@@ -65,7 +46,7 @@ export const ChatHome: FC<ChatPersonaProps> = (props) => {
           <Link href="/persona" className="w-full">
             <Button
               variant="outline"
-              className="w-full flex gap-2 justify-center text-mallingBurgund-800 border-mallingBurgund-800"
+              className="w-full flex gap-2 justify-center text-mallingBurgund-800 border-mallingBurgund-800 text-lg"
             >
               <VenetianMask size={20} /> Personligheter
             </Button>

--- a/src/features/chat-page/chat-header/chat-header.tsx
+++ b/src/features/chat-page/chat-header/chat-header.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ExtensionModel } from "@/features/extensions-page/extension-services/models";
 import { CHAT_DEFAULT_PERSONA } from "@/features/theme/theme-config";
 import { VenetianMask } from "lucide-react";
@@ -7,11 +8,15 @@ import { ChatDocumentModel, ChatThreadModel } from "../chat-services/models";
 import { DocumentDetail } from "./document-detail";
 import { ExtensionDetail } from "./extension-detail";
 import { PersonaDetail } from "./persona-detail";
+import { UpdateChatDeploymentAction } from "../chat-services/chat-thread-service";
+import { chatStore } from "../chat-store";
 
 interface Props {
   chatThread: ChatThreadModel;
   chatDocuments: Array<ChatDocumentModel>;
   extensions: Array<ExtensionModel>;
+  showModelSelect?: boolean;
+  modelMapping?: Record<string, string>;
 }
 
 export const ChatHeader: FC<Props> = (props) => {
@@ -54,6 +59,24 @@ export const ChatHeader: FC<Props> = (props) => {
             installedExtensionIds={props.chatThread.extension}
             chatThreadId={props.chatThread.id}
           />
+          {props.showModelSelect && props.modelMapping && (
+            <form action={UpdateChatDeploymentAction} className="flex gap-2">
+              <input type="hidden" name="chatThreadId" value={props.chatThread.id} />
+              <select
+                name="deploymentName"
+                defaultValue={props.chatThread.deploymentName}
+                className="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                onChange={(e) => chatStore.updateDeploymentName(e.currentTarget.value)}
+                aria-label="Velg modell"
+              >
+                {Object.entries(props.modelMapping).map(([model, deployment]) => (
+                  <option key={model} value={deployment}>
+                    {model}
+                  </option>
+                ))}
+              </select>
+            </form>
+          )}
         </div>
       </div>
     </div>

--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -22,10 +22,13 @@ interface ChatPageProps {
   chatThread: ChatThreadModel;
   chatDocuments: Array<ChatDocumentModel>;
   extensions: Array<ExtensionModel>;
+  modelMapping: Record<string, string>;
 }
 
 export const ChatPage: FC<ChatPageProps> = (props) => {
   const { data: session } = useSession();
+
+  const showModelSelect = props.messages.length === 0;
 
   useEffect(() => {
     chatStore.initChatSession({
@@ -47,6 +50,8 @@ export const ChatPage: FC<ChatPageProps> = (props) => {
         chatThread={props.chatThread}
         chatDocuments={props.chatDocuments}
         extensions={props.extensions}
+        showModelSelect={showModelSelect}
+        modelMapping={props.modelMapping}
       />
       <ChatMessageContainer ref={current}>
         <ChatMessageContentArea>

--- a/src/features/chat-page/chat-store.tsx
+++ b/src/features/chat-page/chat-store.tsx
@@ -123,6 +123,12 @@ class ChatState {
     this.autoScroll = value;
   }
 
+  public updateDeploymentName(deploymentName: string) {
+    if (this.chatThread) {
+      this.chatThread.deploymentName = deploymentName;
+    }
+  }
+
   private reset() {
     this.input = "";
     ResetInputRows();


### PR DESCRIPTION
## Summary
- update Azure OpenAI API version example
- remove model dropdown from home page
- show model selector when opening a new chat
- support updating chat thread deployment
- ensure buttons on chat front page use same font size

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*
