### PR TITLE
Update chat textarea expansion helper

### DIFF
--- a/src/features/chat-page/chat-input/chat-input.tsx
+++ b/src/features/chat-page/chat-input/chat-input.tsx
@@ -2,7 +2,7 @@
 
 import {
   ResetInputRows,
-  UpdateInputRows,
+  UpdateRowsFromTextArea,
   onKeyDown,
   onKeyUp,
   useChatInputDynamicHeight,
@@ -42,6 +42,7 @@ export const ChatInput = () => {
 
   const submitButton = React.useRef<HTMLButtonElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 
   const submit = () => {
     if (formRef.current) {
@@ -59,12 +60,18 @@ export const ChatInput = () => {
       status={uploadButtonLabel}
     >
       <ChatTextInput
+        ref={textAreaRef}
         onBlur={(e) => {
           if (e.currentTarget.value.replace(/\s/g, "").length === 0) {
             ResetInputRows();
           }
         }}
         onKeyDown={(e) => {
+          if (e.key === "Enter" && e.shiftKey) {
+            setTimeout(() => {
+              UpdateRowsFromTextArea(textAreaRef.current);
+            });
+          }
           onKeyDown(e, submit);
         }}
         onKeyUp={(e) => {
@@ -74,7 +81,7 @@ export const ChatInput = () => {
         rows={rows}
         onChange={(e) => {
           chatStore.updateInput(e.currentTarget.value);
-          UpdateInputRows(e.currentTarget.value);
+          UpdateRowsFromTextArea(textAreaRef.current);
         }}
       />
       <ChatInputActionArea>

--- a/src/features/chat-page/chat-input/use-chat-input-dynamic-height.tsx
+++ b/src/features/chat-page/chat-input/use-chat-input-dynamic-height.tsx
@@ -12,16 +12,6 @@ const state = proxy<ChatInputStoreProps>({
   keysPressed: new Set(),
 });
 
-export const SetInputRows = (rows: number) => {
-  if (rows < MAX_ROWS) {
-    state.rows = rows + 1;
-  }
-};
-
-export const UpdateInputRows = (text: string) => {
-  const lines = text.split("\n").length;
-  state.rows = Math.min(lines, MAX_ROWS);
-};
 
 export const SetInputRowsToMax = () => {
   state.rows = MAX_ROWS;
@@ -31,16 +21,22 @@ export const ResetInputRows = () => {
   state.rows = 1;
 };
 
+export const UpdateRowsFromTextArea = (
+  textarea: HTMLTextAreaElement | null
+) => {
+  if (!textarea) return;
+  const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight);
+  if (!lineHeight) return;
+  const rows = Math.ceil(textarea.scrollHeight / lineHeight);
+  state.rows = Math.min(rows, MAX_ROWS);
+};
+
 export const onKeyDown = (
   event: React.KeyboardEvent<HTMLTextAreaElement>,
   submit: () => void
 ) => {
   state.keysPressed.add(event.key);
   const snap = snapshot(state);
-  if (snap.keysPressed.has("Enter") && snap.keysPressed.has("Shift")) {
-    SetInputRows(state.rows + 1);
-  }
-
   if (
     !event.nativeEvent.isComposing &&
     snap.keysPressed.has("Enter") &&

--- a/src/features/ui/chat/chat-input-area/chat-text-input.tsx
+++ b/src/features/ui/chat/chat-input-area/chat-text-input.tsx
@@ -27,7 +27,7 @@ export const ChatTextInput = React.forwardRef<
   return (
     <textarea
       ref={ref}
-      className="p-4 w-full focus:outline-none bg-transparent resize-none"
+      className="p-4 w-full focus:outline-none bg-transparent resize-none overflow-y-auto"
       placeholder="Skriv ny melding her..."
       onPaste={handlePaste}
       {...props}


### PR DESCRIPTION
## Summary
- handle row updates using scrollHeight and line height
- ensure updates run when shift+enter inserts a newline

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871058876f88333bb7ace988bd23403