### PR TITLE
fix: respect selected model and restore new chat input

### DIFF
--- a/src/features/chat-home-page/chat-home.tsx
+++ b/src/features/chat-home-page/chat-home.tsx
@@ -6,6 +6,7 @@ import { PersonaModel } from "@/features/persona-page/persona-services/models";
 import { AI_DESCRIPTION, AI_NAME } from "@/features/theme/theme-config";
 import { Hero } from "@/features/ui/hero";
 import { ScrollArea } from "@/features/ui/scroll-area";
+import { ChatInput } from "@/features/chat-page/chat-input/chat-input";
 import Image from "next/image";
 import { FC } from "react";
 
@@ -16,66 +17,69 @@ interface ChatPersonaProps {
 
 export const ChatHome: FC<ChatPersonaProps> = (props) => {
   return (
-    <ScrollArea className="flex-1">
-      <main className="flex flex-1 flex-col gap-6 pb-6">
-        <Hero
-          title={
-            <>
-              <Image
-                src={"/ai-icon.png"}
-                width={60}
-                height={60}
-                quality={100}
-                alt="ai-icon"
-              />{" "}
-              {AI_NAME}
-            </>
-          }
-          description={AI_DESCRIPTION}
-        ></Hero>
-        <div className="container max-w-4xl flex gap-20 flex-col">
-          <div>
-            <h2 className="text-2xl font-bold mb-3">Extensions</h2>
-
-            {props.extensions && props.extensions.length > 0 ? (
-              <div className="grid grid-cols-3 gap-3">
-                {props.extensions.map((extension) => {
-                  return (
-                    <ExtensionCard
-                      extension={extension}
-                      key={extension.id}
-                      showContextMenu={false}
-                    />
-                  );
-                })}
-              </div>
-            ) :
-              <p className="text-muted-foreground max-w-xl">No extentions created</p>
+    <main className="flex flex-1 relative flex-col">
+      <ScrollArea className="flex-1">
+        <div className="flex flex-1 flex-col gap-6 pb-6">
+          <Hero
+            title={
+              <>
+                <Image
+                  src={"/ai-icon.png"}
+                  width={60}
+                  height={60}
+                  quality={100}
+                  alt="ai-icon"
+                />{" "}
+                {AI_NAME}
+              </>
             }
+            description={AI_DESCRIPTION}
+          ></Hero>
+          <div className="container max-w-4xl flex gap-20 flex-col">
+            <div>
+              <h2 className="text-2xl font-bold mb-3">Extensions</h2>
 
-          </div>
-          <div>
-            <h2 className="text-2xl font-bold mb-3">Personas</h2>
+              {props.extensions && props.extensions.length > 0 ? (
+                <div className="grid grid-cols-3 gap-3">
+                  {props.extensions.map((extension) => {
+                    return (
+                      <ExtensionCard
+                        extension={extension}
+                        key={extension.id}
+                        showContextMenu={false}
+                      />
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-muted-foreground max-w-xl">No extentions created</p>
+              )}
 
-            {props.personas && props.personas.length > 0 ? (
-              <div className="grid grid-cols-3 gap-3">
-                {props.personas.map((persona) => {
-                  return (
-                    <PersonaCard
-                      persona={persona}
-                      key={persona.id}
-                      showContextMenu={false}
-                    />
-                  );
-                })}
-              </div>
-            ) :
-              <p className="text-muted-foreground max-w-xl">No personas created</p>
-            }
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold mb-3">Personas</h2>
+
+              {props.personas && props.personas.length > 0 ? (
+                <div className="grid grid-cols-3 gap-3">
+                  {props.personas.map((persona) => {
+                    return (
+                      <PersonaCard
+                        persona={persona}
+                        key={persona.id}
+                        showContextMenu={false}
+                      />
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-muted-foreground max-w-xl">No personas created</p>
+              )}
+            </div>
           </div>
+          <AddExtension />
         </div>
-        <AddExtension />
-      </main>
-    </ScrollArea>
+      </ScrollArea>
+      <ChatInput />
+    </main>
   );
 };

--- a/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
@@ -13,14 +13,15 @@ export const ChatApiExtensions = async (props: {
   history: ChatCompletionMessageParam[];
   extensions: RunnableToolFunction<any>[];
   signal: AbortSignal;
+  model?: string;
 }): Promise<ChatCompletionStreamingRunner> => {
-  const { userMessage, history, signal, chatThread, extensions } = props;
+  const { userMessage, history, signal, chatThread, extensions, model } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(model);
   const systemMessage = await extensionsSystemMessage(chatThread);
   return openAI.beta.chat.completions.runTools(
     {
-      model: "",
+      model: model ?? process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME!,
       stream: true,
       messages: [
         {

--- a/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
@@ -9,14 +9,15 @@ export const ChatApiMultimodal = (props: {
   userMessage: string;
   file: string;
   signal: AbortSignal;
+  model?: string;
 }): ChatCompletionStreamingRunner => {
-  const { chatThread, userMessage, signal, file } = props;
+  const { chatThread, userMessage, signal, file, model } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(model);
 
   return openAI.beta.chat.completions.stream(
     {
-      model: "",
+      model: model ?? process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME!,
       stream: true,
       max_tokens: 4096,
       messages: [

--- a/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
@@ -17,10 +17,11 @@ export const ChatApiRAG = async (props: {
   userMessage: string;
   history: ChatCompletionMessageParam[];
   signal: AbortSignal;
+  model?: string;
 }): Promise<ChatCompletionStreamingRunner> => {
-  const { chatThread, userMessage, history, signal } = props;
+  const { chatThread, userMessage, history, signal, model } = props;
 
-  const openAI = OpenAIInstance();
+  const openAI = OpenAIInstance(model);
 
   const documentResponse = await SimilaritySearch(
     userMessage,
@@ -64,7 +65,7 @@ ${userMessage}
 `;
 
   const stream: ChatCompletionStreamParams = {
-    model: "",
+    model: model ?? process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME!,
     stream: true,
     messages: [
       {

--- a/src/features/chat-page/chat-services/chat-api/chat-api.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api.ts
@@ -71,6 +71,7 @@ export const ChatAPIEntry = async (props: UserPrompt, signal: AbortSignal) => {
         chatThread: currentChatThread,
         userMessage: props.message,
         history: history,
+        model: props.model,
         signal: signal,
       });
       break;
@@ -79,6 +80,7 @@ export const ChatAPIEntry = async (props: UserPrompt, signal: AbortSignal) => {
         chatThread: currentChatThread,
         userMessage: props.message,
         file: props.multimodalImage,
+        model: props.model,
         signal: signal,
       });
       break;
@@ -88,6 +90,7 @@ export const ChatAPIEntry = async (props: UserPrompt, signal: AbortSignal) => {
         userMessage: props.message,
         history: history,
         extensions: extension,
+        model: props.model,
         signal: signal,
       });
       break;

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -40,6 +40,7 @@ export interface UserPrompt {
   id: string; // thread id
   message: string;
   multimodalImage: string;
+  model?: string;
 }
 
 export interface ChatDocumentModel {

--- a/src/features/chat-page/chat-store.tsx
+++ b/src/features/chat-page/chat-store.tsx
@@ -35,6 +35,7 @@ class ChatState {
   public autoScroll: boolean = false;
   public userName: string = "";
   public chatThreadId: string = "";
+  public model: string = "";
 
   private chatThread: ChatThreadModel | undefined;
 
@@ -113,6 +114,10 @@ class ChatState {
 
   public updateInput(value: string) {
     this.input = value;
+  }
+
+  public updateModel(value: string) {
+    this.model = value;
   }
 
   public stopGeneratingMessages() {
@@ -284,6 +289,7 @@ class ChatState {
     const body = JSON.stringify({
       id: this.chatThreadId,
       message: this.input,
+      model: this.model,
     });
     formData.append("content", body);
 

--- a/src/features/common/services/openai.ts
+++ b/src/features/common/services/openai.ts
@@ -4,26 +4,28 @@ import { AzureOpenAI } from "openai";
 
 const USE_MANAGED_IDENTITIES = process.env.USE_MANAGED_IDENTITIES === "true";
 
-export const OpenAIInstance =  () => {
-  const endpointSuffix = process.env.AZURE_OPENAI_API_ENDPOINT_SUFFIX || "openai.azure.com";
+export const OpenAIInstance = (deployment?: string) => {
+  const endpointSuffix =
+    process.env.AZURE_OPENAI_API_ENDPOINT_SUFFIX || "openai.azure.com";
+  const deploymentName =
+    deployment || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "";
   let token = process.env.AZURE_OPENAI_API_KEY;
   if (USE_MANAGED_IDENTITIES) {
     const credential = new DefaultAzureCredential();
     const scope = "https://cognitiveservices.azure.com/.default";
     const azureADTokenProvider = getBearerTokenProvider(credential, scope);
-    const deployment = process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME;
     const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
     const client = new AzureOpenAI({
       azureADTokenProvider,
-      deployment,
+      deployment: deploymentName,
       apiVersion,
-      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME}`
+      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deploymentName}`,
     });
     return client;
   } else {
     const openai = new OpenAI({
       apiKey: token,
-      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME}`,
+      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deploymentName}`,
       defaultQuery: { "api-version": process.env.AZURE_OPENAI_API_VERSION },
       defaultHeaders: { "api-key": process.env.AZURE_OPENAI_API_KEY },
     });


### PR DESCRIPTION
## Summary
- pass selected model through chat store and API so chosen deployment is used
- add OpenAI client support for custom deployments
- show chat input on New chat page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a18eaaf188333b77a60daff6102af