### PR TITLE
chore: update default model to gpt-5

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,7 +18,7 @@ param name string
 @description('Primary location for all resources')
 param location string
 
-// azure open ai -- regions currently support gpt-4o global-standard
+// azure open ai -- regions currently support gpt-5 global-standard
 @description('Location for the OpenAI resource group')
 @allowed([
   'australiaeast'
@@ -62,12 +62,12 @@ param openAILocation string
 param dalleLocation string
 
 param openAISku string = 'S0'
-param openAIApiVersion string = '2024-08-01-preview'
+param openAIApiVersion string = '2024-12-01-preview'
 
 param chatGptDeploymentCapacity int = 30
-param chatGptDeploymentName string = 'gpt-4o'
-param chatGptModelName string = 'gpt-4o'
-param chatGptModelVersion string = '2024-05-13'
+param chatGptDeploymentName string = 'gpt-5-chat'
+param chatGptModelName string = 'gpt-5-chat'
+param chatGptModelVersion string = '2024-12-01'
 param embeddingDeploymentName string = 'embedding'
 param embeddingDeploymentCapacity int = 120
 param embeddingModelName string = 'text-embedding-ada-002'

--- a/infra/main.json
+++ b/infra/main.json
@@ -67,7 +67,7 @@
     },
     "openAIApiVersion": {
       "type": "string",
-      "defaultValue": "2024-08-01-preview"
+      "defaultValue": "2024-12-01-preview"
     },
     "chatGptDeploymentCapacity": {
       "type": "int",
@@ -75,15 +75,15 @@
     },
     "chatGptDeploymentName": {
       "type": "string",
-      "defaultValue": "gpt-4o"
+      "defaultValue": "gpt-5-chat"
     },
     "chatGptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4o"
+      "defaultValue": "gpt-5-chat"
     },
     "chatGptModelVersion": {
       "type": "string",
-      "defaultValue": "2024-05-13"
+      "defaultValue": "2024-12-01"
     },
     "embeddingDeploymentName": {
       "type": "string",

--- a/src/.env.example
+++ b/src/.env.example
@@ -14,8 +14,8 @@ USE_MANAGED_IDENTITIES=false
 # AZURE_OPENAI_API_VERSION should be Supported versions checkout docs https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
 AZURE_OPENAI_API_KEY=111111
 AZURE_OPENAI_API_INSTANCE_NAME=ABC-aillm-XYZ
-AZURE_OPENAI_API_DEPLOYMENT_NAME=gpt-4o
-AZURE_OPENAI_API_VERSION=2024-10-21
+AZURE_OPENAI_API_DEPLOYMENT_NAME=gpt-5-chat
+AZURE_OPENAI_API_VERSION=2024-12-01-preview
 AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME=embedding
 
 # DALL-E image creation endpoint config

--- a/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-extension.ts
@@ -17,7 +17,7 @@ export const ChatApiExtensions = async (props: {
 }): Promise<ChatCompletionStreamingRunner> => {
   const { userMessage, history, signal, chatThread, extensions, model } = props;
 
-  const openAI = OpenAIInstance(model);
+  const openAI = OpenAIInstance();
   const systemMessage = await extensionsSystemMessage(chatThread);
   return openAI.beta.chat.completions.runTools(
     {

--- a/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-multimodal.tsx
@@ -13,7 +13,7 @@ export const ChatApiMultimodal = (props: {
 }): ChatCompletionStreamingRunner => {
   const { chatThread, userMessage, signal, file, model } = props;
 
-  const openAI = OpenAIInstance(model);
+  const openAI = OpenAIInstance();
 
   return openAI.beta.chat.completions.stream(
     {

--- a/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
@@ -21,7 +21,7 @@ export const ChatApiRAG = async (props: {
 }): Promise<ChatCompletionStreamingRunner> => {
   const { chatThread, userMessage, history, signal, model } = props;
 
-  const openAI = OpenAIInstance(model);
+  const openAI = OpenAIInstance();
 
   const documentResponse = await SimilaritySearch(
     userMessage,

--- a/src/features/common/services/openai.ts
+++ b/src/features/common/services/openai.ts
@@ -4,11 +4,9 @@ import { AzureOpenAI } from "openai";
 
 const USE_MANAGED_IDENTITIES = process.env.USE_MANAGED_IDENTITIES === "true";
 
-export const OpenAIInstance = (deployment?: string) => {
+export const OpenAIInstance = () => {
   const endpointSuffix =
     process.env.AZURE_OPENAI_API_ENDPOINT_SUFFIX || "openai.azure.com";
-  const deploymentName =
-    deployment || process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "";
   let token = process.env.AZURE_OPENAI_API_KEY;
   if (USE_MANAGED_IDENTITIES) {
     const credential = new DefaultAzureCredential();
@@ -17,15 +15,14 @@ export const OpenAIInstance = (deployment?: string) => {
     const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
     const client = new AzureOpenAI({
       azureADTokenProvider,
-      deployment: deploymentName,
       apiVersion,
-      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deploymentName}`,
+      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai`,
     });
     return client;
   } else {
     const openai = new OpenAI({
       apiKey: token,
-      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai/deployments/${deploymentName}`,
+      baseURL: `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.${endpointSuffix}/openai`,
       defaultQuery: { "api-version": process.env.AZURE_OPENAI_API_VERSION },
       defaultHeaders: { "api-key": process.env.AZURE_OPENAI_API_KEY },
     });


### PR DESCRIPTION
## Summary
- switch OpenAI client to model-based endpoint
- use environment deployment name for chat APIs
- default infrastructure settings to gpt-5

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b027422008333ba009f52ac7d1152