### PR TITLE
Simplify chat model selection and restore clear all option

### DIFF
--- a/src/features/chat-page/chat-menu/chat-context-menu.tsx
+++ b/src/features/chat-page/chat-menu/chat-context-menu.tsx
@@ -17,7 +17,7 @@ export const ChatContextMenu = () => {
 
   const handleAction = async () => {
     if (
-      window.confirm("Are you sure you want to delete all the chat threads?")
+      window.confirm("Er du sikker på at du vil tømme alle chattene?")
     ) {
       setIsLoading(true);
       const response = await DeleteAllChatThreads();
@@ -43,7 +43,7 @@ export const ChatContextMenu = () => {
       <DropdownMenuContent side="right" align="start">
         <DropdownMenuItemWithIcon onClick={async () => await handleAction()}>
           <Trash size={18} />
-          <span>Delete all</span>
+          <span>Tøm alle</span>
         </DropdownMenuItemWithIcon>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/features/chat-page/chat-store.tsx
+++ b/src/features/chat-page/chat-store.tsx
@@ -35,7 +35,6 @@ class ChatState {
   public autoScroll: boolean = false;
   public userName: string = "";
   public chatThreadId: string = "";
-  public model: string = "";
 
   private chatThread: ChatThreadModel | undefined;
 
@@ -114,10 +113,6 @@ class ChatState {
 
   public updateInput(value: string) {
     this.input = value;
-  }
-
-  public updateModel(value: string) {
-    this.model = value;
   }
 
   public stopGeneratingMessages() {
@@ -289,7 +284,6 @@ class ChatState {
     const body = JSON.stringify({
       id: this.chatThreadId,
       message: this.input,
-      model: this.model,
     });
     formData.append("content", body);
 


### PR DESCRIPTION
## Summary
- remove model override from chat store so only default deployment is used
- restore Norwegian "Tøm alle" label and confirmation for deleting all chats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b0c38476483339f409b95897135d4